### PR TITLE
Support [model-paths]

### DIFF
--- a/dbt_docstring/__init__.py
+++ b/dbt_docstring/__init__.py
@@ -17,7 +17,7 @@ def _get_models_dirs(dbt_dir):
         exit(1)
     with open(dbt_project_file, "r") as f:
         config = yaml.load(f, Loader=yaml.FullLoader)
-    return config["source-paths"]
+    return config["model-paths"]
 
 
 def _read_dbt_block(sql_file):


### PR DESCRIPTION
`dbt_project.yml` now uses 'model-paths' instead of 'sources-path'. Refer to issue #3.