### PR TITLE
fix: ensure extra keys maintain their original order

### DIFF
--- a/dbt_docstring/__init__.py
+++ b/dbt_docstring/__init__.py
@@ -22,7 +22,7 @@ def sort_dict(d, keys=KEY_ORDER):
     dict: Sorted dictionary.
     """
     sorted_dict = {k: sort_dict(d[k], keys) if isinstance(d[k], dict) else d[k] for k in keys if k in d}
-    extra_keys = set(d.keys()) - set(keys)
+    extra_keys = [k for k in d if k not in keys]
     sorted_dict.update({k: d[k] for k in extra_keys})
     
     return sorted_dict


### PR DESCRIPTION
A small fix to ensure that the extra keys (ones which are not in the KEY_ORDER) are added in their original order. This ensures idempotency and avoids unnecessary changes reordering keys back-and-forth in schema.yml.